### PR TITLE
Fix npm test script glob usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
     "serve": "python3 -m http.server 8080",
     "lint": "npm run validate:content",
     "format": "echo \"TODO: configure formatter\"",
-    "test": "node --test --test-concurrency=1 \"tests/**/*.test.mjs\"",
+    "test": "node --test --test-concurrency=1 tests",
     "build": "node scripts/build.mjs",
-    "test:watch": "node --test --test-concurrency=1 --watch \"tests/**/*.test.mjs\"",
+    "test:watch": "node --test --test-concurrency=1 --watch tests",
     "validate:content": "node scripts/validate-content.mjs"
   },
   "engines": {


### PR DESCRIPTION
## Summary
- update the Node.js test command to target the `tests` directory so the suite runs
- align the watch script with the updated test runner syntax

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68e54121aba08323b8da4c2cc5eef61a